### PR TITLE
Fix compile errors in web API routes

### DIFF
--- a/src/webui/api.cpp
+++ b/src/webui/api.cpp
@@ -2,31 +2,28 @@
 #include "api.hpp"
 #include "api_log.hpp"
 #include "api_live.hpp"
+#include "webui_api_backend.hpp"
 #include <Arduino.h>
-#include <WebServer.h>
-
-WebServer server(80);
+#include <ESPAsyncWebServer.h>
 
 void setupWebAPI() {
     Serial.println("[WebAPI] Registering routes");
 
-    server.on("/status", HTTP_GET, []() {
-        server.send(200, "application/json", R"({"status": "ok"})");
+    server.on("/status", HTTP_GET, [](AsyncWebServerRequest *req) {
+        req->send(200, "application/json", R"({"status": "ok"})");
     });
 
-    server.on("/payloads", HTTP_GET, []() {
+    server.on("/payloads", HTTP_GET, [](AsyncWebServerRequest *req) {
         // In a real build this would list payloads from internal flash or SD
-        server.send(200, "application/json", R"(["hello.txt","evil.txt"])");
+        req->send(200, "application/json", R"(["hello.txt","evil.txt"])");
     });
 
-    server.on("/run", HTTP_POST, []() {
-        String body = server.arg("plain");
-        Serial.println("[WebAPI] Running payload:
-" + body);
+    server.on("/run", HTTP_POST, [](AsyncWebServerRequest *req) {
+        String body = req->arg("plain");
+        Serial.println("[WebAPI] Running payload: " + body);
         // TODO: parse/execute payload here
-        server.send(200, "application/json", R"({"status": "started"})");
+        req->send(200, "application/json", R"({"status": "started"})");
     });
 
-    server.begin();
-    Serial.println("[WebAPI] Server started on port 80");
+    // server.begin(); // started elsewhere
 }

--- a/src/webui/web_server.cpp
+++ b/src/webui/web_server.cpp
@@ -14,7 +14,7 @@ void start_web_server() {
   }
 
 
-  init_api_routes(server);
+  setupWebAPI();
   init_live_routes(server);
 
   server.on("/", HTTP_GET, [](AsyncWebServerRequest *req) {


### PR DESCRIPTION
## Summary
- adapt API routes to use AsyncWebServer
- call `setupWebAPI()` from web server startup

## Testing
- `pio run`

------
https://chatgpt.com/codex/tasks/task_e_686017ca5b7883309625b25a84460348