### PR TITLE
Fix includes and header mismatches

### DIFF
--- a/src/duckyscript/duckyscript_engine.cpp
+++ b/src/duckyscript/duckyscript_engine.cpp
@@ -1,0 +1,7 @@
+#include "duckyscript_engine.hpp"
+
+namespace duckyscript {
+void init() {
+    // Placeholder for future initialization logic
+}
+}

--- a/src/duckyscript/duckyscript_engine.hpp
+++ b/src/duckyscript/duckyscript_engine.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace duckyscript {
+void init();
+}

--- a/src/duckyscript/runner.hpp
+++ b/src/duckyscript/runner.hpp
@@ -1,5 +1,5 @@
 #pragma once
 #include <Arduino.h>
 
-// Execute a full DuckyScript from any Stream source
-void runScript(Stream& stream);
+// Execute a full DuckyScript payload from any Stream source
+void runPayload(Stream& stream);

--- a/src/hid/hid_executor.hpp
+++ b/src/hid/hid_executor.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+inline void init_hid_executor() {}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 #include "display/LGFX_Config.hpp"
 #endif
 
-#include "web/web_server.hpp"
+#include "webui/web_server.hpp"
 #include "duckyscript/duckyscript_engine.hpp"
 #include "hid/hid_executor.hpp"
 #include "usb/usb_config.hpp"

--- a/src/storage/storage_manager.hpp
+++ b/src/storage/storage_manager.hpp
@@ -1,0 +1,3 @@
+#pragma once
+inline void initStorage() {}
+inline void handleWebRequests() {}

--- a/src/usb/usb_config.hpp
+++ b/src/usb/usb_config.hpp
@@ -1,0 +1,2 @@
+#pragma once
+inline void initUSB() {}

--- a/src/webui/web_server.cpp
+++ b/src/webui/web_server.cpp
@@ -5,7 +5,7 @@
 #include "api_live.hpp"
 #include "webui_api_backend.hpp"
 
-void start_web_server() {
+void startWebServer() {
   if (!LittleFS.begin(true)) {
     Serial.println("[LittleFS] Mount failed");
     return;

--- a/src/webui/web_server.hpp
+++ b/src/webui/web_server.hpp
@@ -1,2 +1,2 @@
 #pragma once
-void start_web_server();
+void startWebServer();


### PR DESCRIPTION
## Summary
- fix main web server include path
- align runner header with implementation
- add minimal duckyscript engine and HID executor stubs
- create USB and storage config headers
- rename `start_web_server` to `startWebServer`

## Testing
- `pio run -e lilygo-t-dongle-s3` *(fails: undefined symbols)*
- `pio test` *(fails to build test code)*

------
https://chatgpt.com/codex/tasks/task_e_6861cf60396c8330af2a5f13e925477f